### PR TITLE
feature: Pagination for the craft explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,9 +1578,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1672,13 +1672,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1751,6 +1751,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.1.tgz",
+      "integrity": "sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.9.tgz",
@@ -1799,15 +1809,15 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.14.tgz",
-      "integrity": "sha512-Ma+ZpOJPewtIYl6HZHZckeX1STvDnHTCB2GVINNUlSEn2Am6LddWwfPkIGY0IUFVjUUrr/93XlBwTK6mfLjf0A==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.12",
-        "@inquirer/type": "^3.0.7",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^1.0.1",
+        "@inquirer/figures": "^1.0.14",
+        "@inquirer/type": "^3.0.9",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
@@ -1827,15 +1837,15 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.14.tgz",
-      "integrity": "sha512-yd2qtLl4QIIax9DTMZ1ZN2pFrrj+yL3kgIWxm34SS6uwCr0sIhsNyudUjAo5q3TqI03xx4SEBkUJqZuAInp9uA==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.21.tgz",
+      "integrity": "sha512-MjtjOGjr0Kh4BciaFShYpZ1s9400idOdvQ5D7u7lE6VztPFoyLcVNE5dXBmEEIQq5zi4B9h2kU+q7AVBxJMAkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.14",
-        "@inquirer/type": "^3.0.7",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^10.3.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/type": "^3.0.9"
       },
       "engines": {
         "node": ">=18"
@@ -1872,10 +1882,49 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
+      "integrity": "sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2052,9 +2101,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.9.tgz",
+      "integrity": "sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5293,9 +5342,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6491,34 +6540,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8060,16 +8081,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/karma/node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/karma/node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -9241,16 +9252,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -10801,16 +10802,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "typescript": "~5.8.2",
-        "typescript-eslint": "8.34.1"
+        "typescript-eslint": "8.34.1",
+        "uuid": "^13.0.0"
       }
     },
     "node_modules/@algolia/client-abtesting": {
@@ -11267,6 +11268,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.8.2",
-    "typescript-eslint": "8.34.1"
+    "typescript-eslint": "8.34.1",
+    "uuid": "^13.0.0"
   }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,6 +28,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideThemes(themes),
     { provide: EXPLORE_ITEM_CATEGORIES, useValue: ['Faction'] },
-    { provide: EXPLORE_ITEM_CLASSES, useValue: ['Resource', 'Gem'] }
+    // { provide: EXPLORE_ITEM_CLASSES, useValue: ['Resource', 'Gem'] }
   ]
 };

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -1,6 +1,7 @@
 :host {
   mat-toolbar {
     gap: 0.5rem;
+    margin-bottom: 1rem;
   }
 
   .app-spacer {

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -7,3 +7,6 @@ export * from './src/settings';
 export * from './src/tables';
 export * from './src/calculus';
 export * from './src/instance-pipe';
+export * from './src/data-source-base';
+export * from './src/sync-data-source';
+export * from './src/odata-source';

--- a/src/app/core/src/data-source-base.spec.ts
+++ b/src/app/core/src/data-source-base.spec.ts
@@ -1,0 +1,227 @@
+import { EventEmitter } from '@angular/core';
+import { Sort, SortDirection } from '@angular/material/sort';
+import { PageEvent } from '@angular/material/paginator';
+
+import { PaginatorSource, SorterSource, deepComparator } from './data-source-base';
+
+export interface Data {
+  name: string;
+  value: number | null;
+}
+
+export class TestPaginator implements PaginatorSource {
+  readonly page = new EventEmitter<PageEvent>();
+
+  pageIndex = 0;
+
+  constructor(readonly length: number, readonly pageSize: number) {
+  }
+
+  getPageCount(): number {
+    return Math.ceil(this.length / this.pageSize);
+  }
+
+  setPage(pageIndex: number) {
+    this.pageIndex = Math.max(pageIndex, 0, Math.min(pageIndex, this.getPageCount() - 1));
+    const { pageSize, length } = this;
+    this.page.emit({ pageIndex, pageSize, length });
+  }
+
+  firstPage(): void {
+    this.pageIndex = 0;
+    const { pageIndex, pageSize, length } = this;
+    this.page.emit({ pageIndex, pageSize, length });
+  }
+
+  lastPage(): void {
+    this.pageIndex = Math.max(this.getPageCount() - 1, 0);
+    const { pageIndex, pageSize, length } = this;
+    this.page.emit({ pageIndex, pageSize, length });
+  }
+}
+
+export class TestSorter implements SorterSource {
+  readonly sortChange = new EventEmitter<Sort>();
+  active: string;
+  direction: SortDirection;
+
+  constructor(active: string, direction: SortDirection) {
+    this.active = active;
+    this.direction = direction;
+  }
+
+  sortData(active: string, direction: SortDirection): void {
+    this.active = active;
+    this.direction = direction;
+    this.sortChange.emit({ active, direction });
+  }
+}
+
+export const data: Data[] = [
+  { name: 'First 4', value: null },
+  { name: 'First 2', value: 2 },
+  { name: 'First 3', value: 3 },
+  { name: 'First 6', value: 6 },
+  { name: 'First 7', value: 7 },
+  { name: 'First 5', value: 5 },
+  { name: 'First 1', value: 1 },
+  { name: 'First 10', value: 10 },
+  { name: 'First 8', value: 8 },
+  { name: 'First 9', value: 9 },
+  { name: 'Middle 11', value: 11 },
+  { name: 'Middle 12', value: 12 },
+  { name: 'Middle 14', value: 14 },
+  { name: 'Middle 13', value: 13 },
+  { name: 'Middle 15', value: 15 },
+  { name: 'Middle 18', value: 18 },
+  { name: 'Middle 16', value: 16 },
+  { name: 'Middle 17', value: 17 },
+  { name: 'Middle 19', value: 19 },
+  { name: 'Middle 20', value: null },
+  { name: 'Last 21', value: 21 },
+  { name: 'Last 25', value: 25 },
+  { name: 'Last 23', value: 23 },
+  { name: 'Last 26', value: 26 },
+  { name: 'Last 30', value: null },
+  { name: 'Last 28', value: 28 },
+  { name: 'Last 22', value: 22 },
+  { name: 'Last 27', value: 27 },
+  { name: 'Last 24', value: 24 },
+  { name: 'Last 29', value: 29 }
+];
+
+export function sliceData<T>(data: T[], page?: number | null, size?: number | null): T[] {
+  if (size) {
+    const start = (page ?? 0) * size;
+    return data.slice(start, start + size);
+  }
+  return data;
+}
+
+export function filterData<T>(data: T[], filter?: string | null): T[] {
+  if (filter) {
+    data = data.filter(x => {
+      if (x && typeof x === 'object') {
+        return Object.keys(x).some(p => `${x[p as keyof typeof x]}`.toLowerCase().includes(filter.toLowerCase()));
+      } else {
+        return `${x}`.toLowerCase().includes(filter.toLowerCase());
+      }
+    });
+  }
+  return data;
+}
+
+export function sortData<T>(data: T[], active?: string | null, direction?: SortDirection | null): T[] {
+  if (active && direction) {
+    const path = active.split(/[./]/).map(x => x.trim());
+
+    data = data.sort((a, b) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let valueA = path.reduce<any>((x, name) => x && x[name], a);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let valueB = path.reduce<any>((x, name) => x && x[name], b);
+
+      const valueAType = typeof valueA;
+      const valueBType = typeof valueB;
+
+      if (valueAType !== valueBType) {
+        if (valueAType === 'number') {
+          valueA += '';
+        }
+        if (valueBType === 'number') {
+          valueB += '';
+        }
+      }
+
+      let result = 0;
+      if (valueA > valueB) {
+        result = 1;
+      } else if (valueA < valueB) {
+        result = -1;
+      }
+
+      return result * (direction === 'asc' ? 1 : -1);
+    });
+  }
+  return data;
+}
+
+export interface QueryBlock<T> {
+  query: string;
+  data: T[];
+}
+
+export function getFilteredData<T>(data: T[], ...queries: string[]): QueryBlock<T>[] {
+  const result: QueryBlock<T>[] = [];
+  for (const query of queries) {
+    result.push({ query, data: filterData(data, query) });
+  }
+  return result;
+}
+
+export interface SliceBlock<T> {
+  page: number;
+  size: number;
+  data: T[];
+}
+
+export function getSlicedData<T>(data: T[], size: number): SliceBlock<T>[] {
+  const count = Math.max(Math.ceil(data.length / size), 0);
+  const result: SliceBlock<T>[] = [];
+  for (let page = 0; page < count; page++) {
+    result.push({ page, size, data: sliceData(data, page, size) });
+  }
+  return result;
+}
+
+export interface SortingData {
+  active: string;
+  direction: SortDirection;
+}
+
+export type SortingBlock<T> = SortingData & {
+  active: string;
+  direction: SortDirection;
+  data: T[];
+};
+
+export function getSortedData<T>(data: T[], ...sorts: SortingData[]): SortingBlock<T>[] {
+  const result: SortingBlock<T>[] = [];
+  for (const { active, direction } of sorts) {
+    result.push({ active, direction, data: sortData([...data], active, direction) });
+  }
+  return result;
+}
+
+describe('deepComparator', () => {
+  const tests = [
+    { name: 'undefined values', x: undefined, y: undefined, result: true },
+    { name: 'null values', x: null, y: null, result: true },
+    { name: 'null and undefined', x: null, y: undefined, result: false },
+    { name: 'same booleans', x: true, y: true, result: true },
+    { name: 'different booleans', x: true, y: false, result: false },
+    { name: 'same numbers', x: 42, y: 42, result: true },
+    { name: 'different numbers', x: 42, y: '42', result: false },
+    { name: 'same strings', x: 'test', y: 'test', result: true },
+    { name: 'different strings', x: 'test1', y: 'test2', result: false },
+    { name: 'same date objects', x: new Date('2023-01-01'), y: new Date('2023-01-01'), result: true },
+    { name: 'different date objects', x: new Date('2023-01-01'), y: new Date('2023-01-02'), result: false },
+    { name: 'objects with same properties', x: { a: 1, b: 2 }, y: { a: 1, b: 2 }, result: true },
+    { name: 'objects with different properties', x: { a: 1, b: 2 }, y: { a: 1, b: 3 }, result: false },
+    { name: 'nested objects with same properties', x: { a: { b: 2 } }, y: { a: { b: 2 } }, result: true },
+    { name: 'nested objects with different properties', x: { a: { b: 2 } }, y: { a: { b: 3 } }, result: false },
+    { name: 'arrays with same elements', x: [1, 2, 3], y: [1, 2, 3], result: true },
+    { name: 'arrays with different elements', x: [1, 2, 3], y: [1, 2, 4], result: false },
+    { name: 'arrays with different lengths left', x: [1, 2], y: [1, 2, 3], result: false },
+    { name: 'arrays with different lengths right', x: [1, 2, 3], y: [1, 2], result: false },
+    { name: 'empty objects', x: {}, y: {}, result: true },
+    { name: 'empty arrays', x: [], y: [], result: true },
+    { name: 'empty object and array', x: {}, y: [], result: true }
+  ];
+
+  tests.forEach(({ name, x, y, result }) => {
+    it(`should compare ${name}`, () => {
+      expect(deepComparator(x, y)).toBe(result);
+    });
+  });
+});

--- a/src/app/core/src/data-source-base.ts
+++ b/src/app/core/src/data-source-base.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from "@angular/core";
+import { DataSource } from "@angular/cdk/collections";
+import { Sort, SortDirection } from "@angular/material/sort";
+import { PageEvent } from "@angular/material/paginator";
+import {
+  BehaviorSubject, Subject, Observable, combineLatest, of,
+  distinctUntilChanged, startWith, switchMap, scan, map
+} from "rxjs";
+
+export interface SorterSource {
+  readonly sortChange: EventEmitter<Sort>;
+  active: string;
+  direction: SortDirection;
+}
+
+export interface PaginatorSource {
+  page: Subject<PageEvent>;
+  pageIndex: number;
+  pageSize: number;
+  length: number;
+  firstPage(): void;
+  lastPage(): void;
+}
+
+export type QueryFilters = Record<string, unknown>;
+
+/**
+ * A tuple representing the raw query parameters from data event stream sources.
+ */
+export type QueryParams = [
+  string | null,
+  QueryFilters | null,
+  number
+];
+
+/**
+ * The state of the data source query after processing.
+ */
+export interface QueryState {
+  query: string | null;
+  query$?: boolean;
+  filters: QueryFilters | null;
+  filters$?: boolean;
+  version: number;
+  version$?: boolean;
+}
+
+/**
+ * Extracts the sorting information from the sorter source.
+ * @param sort The sorter source.
+ * @returns The extracted sorting information.
+ */
+function getSort(sort: SorterSource): Sort {
+  const { active, direction } = sort;
+  return { active, direction };
+}
+
+/**
+ * Extracts the pagination information from the paginator source.
+ * @param paginator The paginator source.
+ * @returns The extracted pagination information.
+ */
+function getPage(paginator: PaginatorSource): PageEvent {
+  const { pageIndex, pageSize, length } = paginator;
+  return { pageIndex, pageSize, length };
+}
+
+/**
+ * Converts raw query parameters from event stream sources into a query state object.
+ * @param query The current query string.
+ * @param filters The current set of filters.
+ * @param version The current query version number.
+ * @returns A constructed query state object.
+ */
+function convert([query, filters, version]: QueryParams): QueryState {
+  return { query, filters, version };
+}
+
+/**
+ * Compares and updates the previous and next query states.
+ * @param prev The previous query state.
+ * @param next The next query state.
+ * @returns The updated query state.
+ */
+function iterate(prev: QueryState, next: QueryState): QueryState {
+  next.query$ = prev.query != next.query;
+  next.filters$ = !deepComparator(prev.filters, next.filters);
+  next.version$ = prev.version != next.version;
+  return next;
+}
+
+/**
+ * Performs a deep comparison of two objects.
+ * @param x The left object to compare.
+ * @param y The right object to compare.
+ * @returns True if the objects are equal; otherwise, false.
+ */
+export function deepComparator<T>(x: T, y: T): boolean {
+  if (x === y) {
+    return true;
+  }
+  if (typeof x !== typeof y || x == null || y == null) {
+    return false;
+  }
+  if (x instanceof Date && y instanceof Date) {
+    return x.getTime() === y.getTime();
+  }
+  if (typeof x === 'object' && typeof y === 'object') {
+    const keys = new Set<keyof T>();
+    for (const key in x) {
+      keys.add(key);
+    }
+    for (const key in y) {
+      keys.add(key);
+    }
+    for (const key of keys) {
+      if (!deepComparator(x[key], y[key])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Represents the base data source implementation
+ */
+export abstract class DataSourceBase<T> extends DataSource<T> {
+  readonly #query = new BehaviorSubject<string | null>(null);
+  readonly #filters = new BehaviorSubject<QueryFilters | null>(null);
+  readonly #sorter = new BehaviorSubject<SorterSource | null>(null);
+  readonly #paginator = new BehaviorSubject<PaginatorSource | null>(null);
+  readonly #refresh = new BehaviorSubject<number>(0);
+
+  /**
+   * The data view sorting stream.
+   */
+  protected readonly _sort = this.#sorter.pipe(
+    distinctUntilChanged(),
+    switchMap(sorter => sorter?.sortChange.pipe(
+      startWith(getSort(sorter))
+    ) ?? of(null))
+  );
+
+  /**
+   * The data view page segmentation stream.
+   */
+  protected readonly _page = this.#paginator.pipe(
+    distinctUntilChanged(),
+    switchMap(paginator => paginator?.page.pipe(
+      startWith(getPage(paginator))
+    ) ?? of(null)),
+  );
+
+  /**
+   * The data source entry stream delivered to subscribers upon connection.
+   */
+  protected abstract readonly _entries: Observable<T[]>;
+
+  /**
+   * The current filter query.
+   */
+  get query(): string | null {
+    return this.#query.value;
+  }
+  set query(value: string | null) {
+    this.#query.next(value);
+  }
+
+  /**
+   * The current set of filters to apply.
+   */
+  get filters(): QueryFilters | null {
+    return this.#filters.value;
+  }
+  set filters(value: QueryFilters | null) {
+    this.#filters.next(value);
+  }
+
+  /**
+   * The current sorter source.
+   */
+  get sort(): SorterSource | null {
+    return this.#sorter.value;
+  }
+  set sort(value: SorterSource | null) {
+    this.#sorter.next(value);
+  }
+
+  /**
+   * The current paginator source.
+   */
+  get paginator(): PaginatorSource | null {
+    return this.#paginator.value;
+  }
+  set paginator(value: PaginatorSource | null) {
+    this.#paginator.next(value);
+  }
+
+  /**
+   * The data query state stream.
+   */
+  protected readonly _states = combineLatest([
+    this.#query.pipe(distinctUntilChanged(deepComparator)),
+    this.#filters.pipe(distinctUntilChanged(deepComparator)),
+    this.#refresh
+  ]).pipe(map(convert), scan(iterate));
+
+  /**
+   * Updates the paginator state from the current data source state.
+   * @param length The total count of data items.
+   * @param page The current page event.
+   */
+  protected _update(length: number, page: PageEvent | null) {
+    const paginator = this.#paginator.value;
+    if (paginator && paginator.length !== length && page) {
+      paginator.length = length;
+
+      if (paginator.pageIndex > 0 || page.pageIndex != null) {
+        const lastIndex = Math.max(Math.ceil(length / paginator.pageSize) - 1, 0);
+        if (page.pageIndex == null || page.pageIndex > lastIndex) {
+          page.pageIndex = Math.min(paginator.pageIndex, lastIndex);
+        }
+        if (page.pageIndex !== paginator.pageIndex) {
+          paginator.pageIndex = page.pageIndex;
+        }
+      }
+    }
+  }
+
+  /** @inheritdoc */
+  override connect(): Observable<readonly T[]> {
+    return this._entries;
+  }
+
+  /** @inheritdoc */
+  override disconnect(): void {
+    this.sort = null;
+    this.paginator = null;
+  }
+
+  /**
+   * Refreshes the data source.
+   * @remarks This will re-apply the current filter, sort, and pagination settings.
+   */
+  refresh(): void {
+    let version = this.#refresh.value;
+    this.#refresh.next(++version);
+  }
+
+  /**
+   * Destroys the data source and completes all observables.
+   */
+  destroy(): void {
+    this.#refresh.complete();
+    this.#paginator.complete();
+    this.#sorter.complete();
+    this.#filters.complete();
+    this.#query.complete();
+  }
+}

--- a/src/app/core/src/odata-source.spec.ts
+++ b/src/app/core/src/odata-source.spec.ts
@@ -1,0 +1,210 @@
+import { EventEmitter } from '@angular/core';
+import { isDataSource } from '@angular/cdk/collections';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { delay, firstValueFrom, of, Subscription, timer } from 'rxjs';
+
+import * as uuid from 'uuid';
+
+import { create, ODataSource } from './odata-source';
+
+export interface Data {
+  index: number;
+  text: string;
+}
+
+export const content: Data[] = [...Array(100).keys()].map(x => ({
+  index: x,
+  text: uuid.v4()
+}));
+
+class TestPaginator {
+  pageIndex = 0;
+
+  page = new EventEmitter<PageEvent>();
+
+  constructor(public length: number, public pageSize: number) {
+  }
+
+  nextPage(): void {
+    const previousPageIndex = this.pageIndex;
+    this.pageIndex = Math.min(this.getNumberOfPages() - 1, previousPageIndex + 1);
+    const { length, pageIndex, pageSize } = this;
+    this.page.emit({ length, pageIndex, pageSize, previousPageIndex });
+  }
+
+  previousPage(): void {
+    void 0;
+  }
+
+  firstPage(): void {
+    const previousPageIndex = this.pageIndex;
+    this.pageIndex = 0;
+    const { length, pageIndex, pageSize } = this;
+    this.page.emit({ length, pageIndex, pageSize, previousPageIndex });
+  }
+
+  lastPage(): void {
+    const previousPageIndex = this.pageIndex;
+    this.pageIndex = Math.min(this.getNumberOfPages() - 1, 0);
+    const { length, pageIndex, pageSize } = this;
+    this.page.emit({ length, pageIndex, pageSize, previousPageIndex });
+  }
+
+  hasPreviousPage(): boolean {
+    return this.pageIndex > 0;
+  }
+
+  hasNextPage(): boolean {
+    return this.pageIndex < this.getNumberOfPages();
+  }
+
+  getNumberOfPages(): number {
+    return Math.ceil(this.length / this.pageSize);
+  }
+}
+
+const filterContent = <T>(filter: string | null | undefined): (value: T, index: number, array: T[]) => unknown => x => {
+  if (filter) {
+    for (const name in x) {
+      const value = x[name as keyof T];
+      if (typeof value === 'string' && value.includes(filter)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+};
+
+describe('ODataSource', () => {
+  const subscriptions: Subscription[] = [];
+  let source: ODataSource<Data>;
+
+  beforeEach(() => {
+    source = new ODataSource<Data>(query => {
+      return of(create(content.filter(filterContent(query.$filter)), query.$top, query.$skip)).pipe(delay(100));
+    });
+  });
+
+  afterEach(() => {
+    while (subscriptions.length > 0) {
+      subscriptions.shift()?.unsubscribe();
+    }
+  });
+
+  it('should create', async () => {
+    expect(source).toBeTruthy();
+    expect(await firstValueFrom(source.loading$)).toBeFalse();
+  });
+
+  it('should detect data source instance', () => {
+    expect(isDataSource(source)).toBeTruthy();
+  });
+
+  it('should connect to data source', async () => {
+    const connection = source.connect();
+
+    expect(connection).toBeTruthy();
+  });
+
+  it('should not load on connect', async () => {
+    const connection = source.connect();
+
+    expect(connection).toBeTruthy();
+    expect(await firstValueFrom(source.loading$)).toBeFalse();
+  });
+
+  it('should load on connection subscribe', async () => {
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+    expect(await firstValueFrom(source.loading$)).toBeFalse();
+  });
+
+  it('should get data on connect', async () => {
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+
+    expect(await firstValueFrom(connection)).toEqual(content);
+  });
+
+  it('should get paginated data on connect', async () => {
+    const pageSize = 10;
+    source.paginator = new TestPaginator(content.length, pageSize) as MatPaginator;
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    await (firstValueFrom(timer(300)));
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+
+    const request = firstValueFrom(connection);
+    expect(await request).toEqual(content.slice(0, pageSize));
+    expect(source.paginator?.length).toEqual(content.length);
+  });
+
+  it('should query data', async () => {
+    const query = '5';
+    source.query = query;
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+
+    const request = firstValueFrom(connection);
+    const result = content.filter(x => x.text.includes(query));
+    expect(await request).toEqual(result);
+  });
+
+  it('should query paginated data', async () => {
+    const query = '5';
+    const pageSize = 10;
+    source.query = query;
+    source.paginator = new TestPaginator(content.length, pageSize) as MatPaginator;
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+
+    const request = firstValueFrom(connection);
+    const expected = content.filter(x => x.text.includes(query));
+    expect(await request).toEqual(expected.slice(0, pageSize));
+    expect(source.paginator?.length).toEqual(expected.length);
+  });
+
+  it('should refresh current page', async () => {
+    const connection = source.connect();
+    subscriptions.push(connection.subscribe());
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+    expect(await firstValueFrom(connection)).toEqual(content);
+
+    source.refresh();
+
+    expect(await firstValueFrom(source.loading$)).toBeTrue();
+    while (await firstValueFrom(source.loading$)) {
+      await (firstValueFrom(timer(100)));
+    }
+    expect(await firstValueFrom(connection)).toEqual(content);
+  })
+});

--- a/src/app/core/src/odata-source.ts
+++ b/src/app/core/src/odata-source.ts
@@ -1,0 +1,86 @@
+import { Sort } from '@angular/material/sort';
+import { PageEvent } from '@angular/material/paginator';
+import {
+  BehaviorSubject, Observable, combineLatest,
+  finalize, map, shareReplay, switchMap, tap
+} from 'rxjs';
+
+import { DataSourceBase, QueryState } from './data-source-base';
+
+export interface ODataQuery {
+  $filter?: string | null;
+  $expand?: string | null;
+  $orderby?: string | null;
+  $top?: number | null;
+  $skip?: number | null;
+}
+
+export interface ODataResultSet<T> {
+  offset: number;
+  count: number;
+  elements: T[];
+  nextLink?: string;
+}
+
+export type ODataEndpointFn<T> = (query: ODataQuery) => Observable<ODataResultSet<T>>;
+
+function getOrderBy(sort: Sort | null): string | null {
+  const { active, direction } = sort ?? {};
+  return active && direction ? `${active} ${direction}` : null;
+}
+
+function getSkipIndex(page: PageEvent | null): number | undefined {
+  const { pageIndex, pageSize } = page ?? {};
+  if (pageIndex != null && pageSize != null) {
+    return pageIndex * pageSize;
+  }
+  return undefined;
+}
+
+export function buildQuery(state: QueryState, sort: Sort | null, page: PageEvent | null): ODataQuery {
+  const { query } = state;
+  return {
+    $filter: query,
+    $orderby: getOrderBy(sort),
+    $top: page?.pageSize,
+    $skip: getSkipIndex(page)
+  };
+}
+
+export function create<T>(elements: T[], top?: number | null, skip?: number | null): ODataResultSet<T> {
+  return {
+    offset: skip ?? 0,
+    count: elements.length,
+    elements: elements.slice(skip ?? 0, top ?? elements.length)
+  };
+}
+
+export function convert<T, U>(l: ODataResultSet<T>, callbackfn: (value: T, index: number, array: T[]) => U): ODataResultSet<U> {
+  return {
+    offset: l.offset,
+    count: l.count,
+    elements: l.elements.filter(x => x).map(callbackfn),
+    nextLink: l.nextLink
+  };
+}
+
+export class ODataSource<T> extends DataSourceBase<T> {
+  readonly #loading = new BehaviorSubject<boolean>(false);
+
+  readonly loading$ = this.#loading.asObservable();
+
+  /** @inheritdoc */
+  protected readonly _entries = combineLatest([this._states, this._sort, this._page]).pipe(
+    tap(() => this.#loading.next(true)),
+    switchMap(state => this._endpoint(buildQuery(...state)).pipe(
+      map(data => {
+        this._update(data.count, state[2]);
+        return data.elements;
+      }),
+      finalize(() => this.#loading.next(false))
+    )), shareReplay(1));
+
+  constructor(private readonly _endpoint: ODataEndpointFn<T>) {
+    super();
+  }
+}

--- a/src/app/core/src/sync-data-source.spec.ts
+++ b/src/app/core/src/sync-data-source.spec.ts
@@ -1,0 +1,236 @@
+import { Subscription, firstValueFrom } from 'rxjs';
+
+import {
+  getFilteredData, getSlicedData, getSortedData, TestPaginator, TestSorter,
+  filterData, sliceData, sortData, Data, data
+} from './data-source-base.spec';
+
+import { SyncDataSource } from './sync-data-source';
+
+describe('SyncDataSource', () => {
+  const subscriptions: Subscription[] = [];
+
+  let dataSource: SyncDataSource<Data>;
+
+  beforeEach(() => {
+    dataSource = new SyncDataSource<Data>([...data.map(x => ({ ...x }))]);
+  });
+
+  afterEach(() => {
+    while (subscriptions.length > 0) {
+      subscriptions.shift()?.unsubscribe();
+    }
+  });
+
+  it('should create an instance', () => {
+    expect(dataSource).toBeTruthy();
+  });
+
+  it('should connect to data source', () => {
+    const connection = dataSource.connect();
+    expect(connection).toBeTruthy();
+  });
+
+  it('should disconnect from data source', () => {
+    expect(() => dataSource.disconnect()).not.toThrow();
+  });
+
+  it('should get data on connect to data source', async () => {
+    const connection = dataSource.connect();
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(data);
+  });
+
+  it('should set data on connect to data source', async () => {
+    const connection = dataSource.connect();
+    subscriptions.push(connection.subscribe());
+    expect(dataSource.data).toEqual(await firstValueFrom(connection));
+  });
+
+  it('should paginate by paginator attached', async () => {
+    const pageSize = 5;
+    const connection = dataSource.connect();
+    dataSource.paginator = new TestPaginator(data.length, pageSize);
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(sliceData(data, 0, pageSize));
+  });
+
+  getSlicedData(data, 7).forEach(block => {
+    it(`should get paginated data for page ${block.page} and size ${block.size}`, async () => {
+      const pageSize = block.size;
+      const connection = dataSource.connect();
+      const paginator = new TestPaginator(data.length, pageSize);
+      dataSource.paginator = paginator;
+
+      subscriptions.push(connection.subscribe());
+      paginator.setPage(block.page);
+      expect(await firstValueFrom(connection)).toEqual(block.data);
+    });
+  });
+
+  getSlicedData(data, 10).forEach(block => {
+    it(`should get paginated data for page ${block.page} and size ${block.size}`, async () => {
+      const pageSize = block.size;
+      const connection = dataSource.connect();
+      const paginator = new TestPaginator(data.length, pageSize);
+      dataSource.paginator = paginator;
+
+      subscriptions.push(connection.subscribe());
+      paginator.setPage(block.page);
+      expect(await firstValueFrom(connection)).toEqual(block.data);
+    });
+  });
+
+  getSlicedData(data, 20).forEach(block => {
+    it(`should get paginated data for page ${block.page} and size ${block.size}`, async () => {
+      const pageSize = block.size;
+      const connection = dataSource.connect();
+      const paginator = new TestPaginator(data.length, pageSize);
+      dataSource.paginator = paginator;
+
+      subscriptions.push(connection.subscribe());
+      paginator.setPage(block.page);
+      expect(await firstValueFrom(connection)).toEqual(block.data);
+    });
+  });
+
+  it('should get data on paginator clear', async () => {
+    const pageSize = 5;
+    const connection = dataSource.connect();
+    dataSource.paginator = new TestPaginator(data.length, pageSize);
+    dataSource.paginator = null;
+
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(data);
+  });
+
+  it('should update paginator last page on data change', async () => {
+    const pageSize = 5;
+    const connection = dataSource.connect();
+    dataSource.paginator = new TestPaginator(data.length, pageSize);
+
+    subscriptions.push(connection.subscribe());
+    dataSource.paginator.lastPage();
+    dataSource.data = filterData(data, 'first');
+    expect(await firstValueFrom(connection)).toEqual(
+      sliceData(filterData(data, 'first'), 1, 5)
+    );
+  });
+
+  it('should set query value', async () => {
+    dataSource.query = 'first';
+    expect(dataSource.query).toBe('first');
+  });
+
+  getFilteredData(data, 'first', 'middle', 'last').forEach(({ query, data }) => {
+    it(`should get filtered data for clause ${query}`, async () => {
+      const connection = dataSource.connect();
+      dataSource.query = query;
+
+      subscriptions.push(connection.subscribe());
+      expect(await firstValueFrom(connection)).toEqual(data);
+    });
+  });
+
+  it('should reset page on query change', async () => {
+    const pageSize = 5;
+    const connection = dataSource.connect();
+    dataSource.paginator = new TestPaginator(data.length, pageSize);
+
+    subscriptions.push(connection.subscribe());
+    dataSource.paginator.lastPage();
+    dataSource.query = 'first';
+    expect(await firstValueFrom(connection)).toEqual(
+      sliceData(filterData(data, 'first'), 0, pageSize)
+    );
+  });
+
+  it('should get data on filter clear', async () => {
+    const connection = dataSource.connect();
+    dataSource.query = 'first';
+    dataSource.query = null;
+
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(data);
+  });
+
+  it('should filter data with custom predicate', async () => {
+    const builder = () => (x: Data) => !!x.value && x.value > 5;
+    dataSource = new SyncDataSource<Data>([...data.map(x => ({ ...x }))]);
+    dataSource.predicate = builder;
+    const connection = dataSource.connect();
+    dataSource.query = 'first';
+    dataSource.filters = {};
+
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(
+      filterData(data, 'first').filter(builder())
+    );
+  });
+
+  it('should refresh when custom predicate condition changes', async () => {
+    let condition = 10;
+    const builder = () => (x: Data) => !!x.value && x.value > condition;
+    dataSource = new SyncDataSource<Data>([...data.map(x => ({ ...x }))]);
+    dataSource.predicate = builder;
+    const connection = dataSource.connect();
+    dataSource.query = 'first';
+    dataSource.filters = {};
+
+    subscriptions.push(connection.subscribe());
+    condition = 1;
+    dataSource.refresh();
+    expect(await firstValueFrom(connection)).toEqual(
+      filterData(data, 'first').filter(builder())
+    );
+  });
+
+  const sortCases = [
+    { active: 'name', direction: null! },
+    { active: 'name', direction: 'asc' },
+    { active: 'name', direction: 'desc' },
+    { active: 'value', direction: null! },
+    { active: 'value', direction: 'asc' },
+    { active: 'value', direction: 'desc' }
+  ] as const;
+
+  it('should sort by sorter attached', async () => {
+    const connection = dataSource.connect();
+    dataSource.sort = new TestSorter('name', 'asc');
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(
+      sortData([...data], 'name', 'asc')
+    );
+  });
+
+  getSortedData(data, ...sortCases).forEach(block => {
+    it(`should sort data on '${block.active}' to '${block.direction ?? 'origin'}`, async () => {
+      const connection = dataSource.connect();
+      dataSource.sort = new TestSorter(block.active, block.direction);
+
+      subscriptions.push(connection.subscribe());
+      expect(await firstValueFrom(connection)).toEqual(block.data);
+    });
+  });
+
+  it('should get data on sorter clear', async () => {
+    const connection = dataSource.connect();
+    dataSource.sort = new TestSorter('name', 'asc');
+    dataSource.sort = null;
+
+    subscriptions.push(connection.subscribe());
+    expect(await firstValueFrom(connection)).toEqual(data);
+  });
+
+  it('should get sort data on update', async () => {
+    const connection = dataSource.connect();
+    const sort = new TestSorter('name', 'asc');
+    dataSource.sort = sort;
+
+    subscriptions.push(connection.subscribe());
+    sort.sortData('value', 'desc');
+    expect(await firstValueFrom(connection)).toEqual(
+      sortData([...data], 'value', 'desc')
+    );
+  });
+});

--- a/src/app/core/src/sync-data-source.ts
+++ b/src/app/core/src/sync-data-source.ts
@@ -1,0 +1,358 @@
+import { _isNumberValue } from "@angular/cdk/coercion";
+import { Sort } from "@angular/material/sort";
+import { PageEvent } from "@angular/material/paginator";
+import { BehaviorSubject, combineLatest, map, shareReplay } from "rxjs";
+
+import { DataSourceBase, QueryFilters, QueryState } from "./data-source-base";
+
+/**
+ * A type representing a property path as an array of strings.
+ */
+export type Path = string[];
+
+/**
+ * A function that traverses an object and returns all property paths leading to primitive values.
+ * @param value The object to traverse.
+ * @returns An array of property paths leading to primitive values.
+ * @typeparam T The type of the object.
+ */
+export type TraverserFn<T> = (value: T) => Path[];
+
+/**
+ * A function that accesses a property value from a object based on the specified path.
+ * @param data The object to access.
+ * @param path The property path to access.
+ * @returns The value at the specified path if found; otherwise, undefined.
+ * @typeparam T The type of the object.
+ * @typeparam R The type of a property value.
+ */
+export type AccessorFn<T, R = unknown> = (data: T, path: Path) => R;
+
+/**
+ * A function that defines a predicate for filtering data.
+ * @param value The current element being processed in the array.
+ * @param index The index of the current element being processed in the array.
+ * @returns True to keep the element, false otherwise.
+ * @typeparam T The type of the object.
+ */
+export type PredicateFn<T> = (value: T, index?: number) => boolean;
+
+/**
+ * A factory function that creates a predicate function based on the provided search term.
+ * @param term The search term to apply.
+ * @returns A predicate function that can be used to filter data.
+ * @typeparam T The type of the object.
+ */
+export type PredicateFactory<T> = (accessor: AccessorFn<T>, term: string) => PredicateFn<T>;
+
+/**
+ * A factory function that creates a predicate function based on the provided query filters.
+ * @param filters The query filters to apply.
+ * @returns A predicate function that can be used to filter data.
+ * @typeparam T The type of the object.
+ */
+export type PredicateFilterFactory<T> = (filters: QueryFilters) => PredicateFn<T>;
+
+/**
+ * A function that defines a sorter for sorting data.
+ * @param a The left element to compare.
+ * @param b The right element to compare.
+ * @returns A negative number if `a` should come before `b`, a positive number if `a` should
+ * @typeparam T The type of the object.
+ * come after `b`, or zero if they are equal.
+ */
+export type SorterFn<T> = (a: T, b: T) => number;
+
+/**
+ * A factory function that creates a sorter function based on the specified property and direction.
+ * @param path The property path to sort by.
+ * @param direction The sort direction ("asc" or "desc").
+ * @returns A sorter function that can be used to sort data.
+ * @typeparam T The type of the object.
+ */
+export type SorterFactory<T> = (path: string, direction: string) => SorterFn<T>;
+
+/**
+ * Gets all property descriptors of an object, including inherited ones.
+ * @param object The object to get property descriptors from.
+ * @returns An array of property descriptors.
+ */
+function getObjectProperties(object: object): [string, PropertyDescriptor][] {
+  const properties = new Map<string, PropertyDescriptor>();
+  const traverse = (prototype: object) => {
+    if (!prototype || prototype === Object.prototype) {
+      return;
+    }
+    traverse(Object.getPrototypeOf(prototype));
+    for (const key of Object.getOwnPropertyNames(prototype)) {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+      if (descriptor && typeof descriptor.get === 'function') {
+        properties.set(key, descriptor);
+      }
+    }
+  };
+  traverse(object);
+  return Array.from(properties.entries());
+}
+
+/**
+ * Traverses an object and returns all property paths leading to primitive values.
+ * @param value The object to traverse.
+ * @returns An array of property paths leading to primitive values.
+ */
+export function traverser<T>(value: T): Path[] {
+  const paths: Path[] = [];
+  const visited = new WeakSet<object>();
+  const traverse = (object: unknown, ...path: Path) => {
+    if (object) {
+      switch (typeof object) {
+        case 'boolean':
+        case 'number':
+        case 'bigint':
+        case 'string':
+          paths.push(path);
+          break;
+
+        case 'object':
+          if (!visited.has(object) && !Array.isArray(object)) {
+            visited.add(object);
+            for (const [key, value] of Object.entries(object)) {
+              traverse(value, ...path, key);
+            }
+            for (const [key, property] of getObjectProperties(object)) {
+              property.get && traverse(property.get.call(object), ...path, key);
+            }
+          }
+          break;
+      }
+    }
+  };
+  traverse(value);
+  return paths;
+}
+
+/**
+ * Gets the value at the specified path from the object.
+ * @param data The object to access.
+ * @param path The path to the property to access.
+ * @returns The value at the specified path if found; otherwise, undefined.
+ * @typeparam T The type of the object.
+ */
+export function accessor<T>(data: T, path: Path): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const value = path.reduce<any>((x, name) => x && x[name], data);
+
+  if (_isNumberValue(value)) {
+    const number = Number(value);
+    return number < 9007199254740991 ? number : value;
+  }
+
+  return value;
+}
+
+/**
+ * Compares two values for sorting.
+ * @param a The first value to compare.
+ * @param b The second value to compare.
+ * @returns A negative number if `valueA` should come before `valueB`, a positive number if `valueA`
+ * should come after `valueB`, or zero if they are equal.
+ */
+export function comparer(a: unknown, b: unknown): number {
+  const aType = typeof a;
+  const bType = typeof b;
+
+  if (aType !== bType) {
+    if (aType === 'number') {
+      a += '';
+    }
+    if (bType === 'number') {
+      b += '';
+    }
+  }
+
+  let result = 0;
+  if (a != null && b != null) {
+    if (a > b) {
+      result = 1;
+    } else if (a < b) {
+      result = -1;
+    }
+  } else if (a != null) {
+    result = 1;
+  } else if (b != null) {
+    result = -1;
+  }
+
+  return result;
+}
+
+/**
+ * A default filter predicate that checks if the filter string is contained
+ * in any property of the object (case-insensitive).
+ * @param traverser The function to traverse objects and get property paths.
+ * @param accessor The function to access property values from objects.
+ * @param term The search term to apply.
+ * @returns A predicate function that can be used to filter data.
+ * @typeparam T The type of the object.
+ */
+export function predicate<T>(traverser: TraverserFn<T>, accessor: AccessorFn<T>, term: string): PredicateFn<T> {
+  return (source: T) => {
+    const paths = traverser(source);
+    for (const path of paths) {
+      const value = accessor(source, path);
+      switch (typeof value) {
+        case 'boolean':
+        case 'number':
+        case 'bigint':
+          if (value.toString().includes(term.trim().toLowerCase())) {
+            return true;
+          }
+          break;
+        case 'string':
+          if (value.toLowerCase().includes(term.trim().toLowerCase())) {
+            return true;
+          }
+      }
+    }
+    return false;
+  };
+}
+
+/**
+ * Creates a sorter function based on the specified property and direction.
+ * @param accessor The function to access property values from objects.
+ * @param property The property to sort by.
+ * @param direction The sort direction ("asc" or "desc").
+ * @returns A sorter function that can be used to sort data.
+ * @typeparam T The type of the object.
+ */
+export function sorter<T>(accessor: AccessorFn<T>, property?: string | null, direction?: string | null): SorterFn<T> {
+  const path = property?.split(/[./]/).map(x => x.trim()) ?? [];
+  return (a: T, b: T): number => {
+    const valueA = accessor(a, path);
+    const valueB = accessor(b, path);
+
+    const result = comparer(valueA, valueB);
+
+    return direction === 'desc' ? -result : result;
+  };
+}
+
+/**
+ * Represents the data source that manages a local array of data.
+ * @param T The type of an array element.
+ */
+export class SyncDataSource<T> extends DataSourceBase<T> {
+  readonly #data = new BehaviorSubject<T[]>([]);
+  readonly #state = { reset: false };
+
+  readonly #filtered = combineLatest([this.#data, this._states]).pipe(
+    map(args => this.#filter(...args)),
+    shareReplay(1)
+  );
+
+  readonly #sorted = combineLatest([this.#filtered, this._sort]).pipe(
+    map(args => this.#sorter(...args)),
+    shareReplay(1)
+  );
+
+  /** @inheritdoc */
+  protected readonly _entries = combineLatest([this.#sorted, this._page]).pipe(
+    map(args => this.#slicer(...args)),
+    shareReplay(1)
+  );
+
+  /**
+   * The data array managed by the data source.
+   */
+  get data() {
+    return this.#data.value;
+  }
+  set data(data: T[]) {
+    this.#data.next(Array.isArray(data) ? data : []);
+  }
+
+  /**
+   * The traverser function used to get property paths from objects.
+   */
+  get traverser(): TraverserFn<T> {
+    return this.#traverser;
+  }
+  set traverser(value: TraverserFn<T>) {
+    this.#traverser = value ?? traverser;
+  }
+  #traverser: TraverserFn<T> = traverser;
+
+  /**
+   * The accessor function used to access property values from objects.
+   */
+  get accessor(): AccessorFn<T, unknown> {
+    return this.#accessor;
+  }
+  set accessor(value: AccessorFn<T, unknown>) {
+    this.#accessor = value ?? accessor;
+  }
+  #accessor: AccessorFn<T, unknown> = accessor;
+
+  /**
+   * The predicate filter factory function.
+   */
+  get predicate(): PredicateFilterFactory<T> | null {
+    return this.#predicate;
+  }
+  set predicate(value: PredicateFilterFactory<T> | null) {
+    this.#predicate = value;
+  }
+  #predicate: PredicateFilterFactory<T> | null = null;
+
+  /**
+   * Constructs a new instance of an array data source.
+   * @param data The initial data array.
+   */
+  constructor(data: T[] = []) {
+    super();
+    data.length && this.#data.next(data);
+  }
+
+  #filter(data: T[], state: QueryState): T[] {
+    const { query, query$, filters, filters$ } = state;
+    if (query) {
+      data = data.filter(predicate(this.#traverser, this.#accessor, query));
+    }
+    if (filters && this.#predicate) {
+      data = data.filter(this.#predicate(filters));
+    }
+    if (query$ || filters$) {
+      this.#state.reset = true;
+    }
+    return data;
+  }
+
+  #sorter(data: T[], sort: Sort | null): T[] {
+    const { active, direction } = sort || {};
+    if (active && direction) {
+      data = [...data].sort(sorter(this.#accessor, active, direction));
+    }
+    return data;
+  }
+
+  #slicer(data: T[], page: PageEvent | null): T[] {
+    if (this.#state.reset && page) {
+      page.pageIndex = 0;
+      this.#state.reset = false;
+    }
+    this._update(data.length, page);
+    const { pageIndex, pageSize } = page || {};
+    if (pageIndex != null && pageSize) {
+      const start = pageIndex * pageSize;
+      data = data.slice(start, start + pageSize);
+    }
+    return data;
+  }
+
+  /** @inheritdoc */
+  override destroy(): void {
+    this.#data.complete();
+    super.destroy();
+  }
+}

--- a/src/app/features/artisan/src/assembly.ts
+++ b/src/app/features/artisan/src/assembly.ts
@@ -87,12 +87,22 @@ export class Assembly extends Purchase implements Persistent<AssemblyState> {
   /**
    * The unit differential between the crafting cost and the market price.
    */
+  get spread(): number | null {
+    return this.#spread();
+  }
+  readonly #spread = computed(() =>
+    this.#projection()?.spread ?? null
+  );
+
+  /**
+   * The margin percentage between the crafting cost and the market price.
+   */
   get margin(): number | null {
     return this.#margin();
   }
-  readonly #margin = computed(() => {
-    return this.#projection()?.margin ?? null;
-  });
+  readonly #margin = computed(() =>
+    this.#projection()?.margin ?? null
+  );
 
   /**
    * The crafting profit of the the assembly based crafting state and parameters.

--- a/src/app/features/artisan/src/entity.ts
+++ b/src/app/features/artisan/src/entity.ts
@@ -10,8 +10,9 @@ import { Purchase } from './purchase';
  * Represents an entity in the artisan system, which can be a master item or housing.
  */
 export class Entity implements Deferrable, Material<Purchase> {
-  readonly #item: MasterItemDefinitions | HouseItems;
+  readonly #artisan: Artisan;
   readonly #id: string;
+  readonly #item: MasterItemDefinitions | HouseItems;
 
   /**
    * A unique identifier.
@@ -90,7 +91,7 @@ export class Entity implements Deferrable, Material<Purchase> {
     return this.#price();
   }
   readonly #price = computed(() =>
-    !this.#item.BindOnPickup ? this.artisan.gaming.get(this.id) : null
+    !this.#item.BindOnPickup ? this.#artisan.gaming.get(this.id) : null
   );
 
   /**
@@ -100,7 +101,7 @@ export class Entity implements Deferrable, Material<Purchase> {
    * @throws Will throw an error if the artisan instance is invalid.
    * @throws Will throw an error if the item data is invalid.
    */
-  constructor(protected readonly artisan: Artisan, item: MasterItemDefinitions | HouseItems) {
+  constructor(artisan: Artisan, item: MasterItemDefinitions | HouseItems) {
     if (!artisan) {
       throw new Error('Invalid Artisan instance.');
     }
@@ -108,6 +109,7 @@ export class Entity implements Deferrable, Material<Purchase> {
       throw new Error('Invalid item data.');
     }
 
+    this.#artisan = artisan;
     this.#item = item;
     if (isMasterItem(item)) {
       this.#id = item.ItemID;

--- a/src/app/features/artisan/src/projection.spec.ts
+++ b/src/app/features/artisan/src/projection.spec.ts
@@ -90,14 +90,14 @@ describe('Projection', () => {
     expect(projection.effective).toBe(2);
   });
 
-  it('should get crafting margin', () => {
+  it('should get crafting spread', () => {
     const assembly = jasmine.createSpyObj<Assembly>('Assembly', { boosted: true, requested: 1 });
     const craftable = service.getCraftable('IngotT2');
     const [blueprint] = craftable.blueprints;
 
     const materials = new Materials();
     const projection = new Projection(assembly, blueprint, materials);
-    expect(projection.margin).toBe(2);
+    expect(projection.spread).toBe(2);
   });
 
   it('should get crafting profit', () => {

--- a/src/app/features/artisan/src/projection.ts
+++ b/src/app/features/artisan/src/projection.ts
@@ -98,8 +98,6 @@ export class Projection {
     return product(product(spread, sign), this.assembly.requested());
   });
 
-  // get
-
   /**
    * The effective volume of materials required for the projection based on the craft parameters.
    */

--- a/src/app/features/artisan/src/projection.ts
+++ b/src/app/features/artisan/src/projection.ts
@@ -68,13 +68,23 @@ export class Projection {
   /**
    * The unit differential between the crafting cost and the market price.
    */
-  get margin(): number | null {
-    return this.#margin();
+  get spread(): number | null {
+    return this.#spread();
   }
-  readonly #margin = computed(() => {
+  readonly #spread = computed(() => {
     const price = this.blueprint.entity.price;
     return price && subtract(price, this.#cost());
   });
+
+  /**
+   * The margin percentage between the crafting cost and the market price.
+   */
+  get margin(): number | null {
+    return this.#margin();
+  }
+  readonly #margin = computed(() =>
+    ratio(this.#spread(), this.blueprint.entity.price)
+  );
 
   /**
    * The crafting profit of the projection based crafting state and parameters.
@@ -83,10 +93,12 @@ export class Projection {
     return this.#profit();
   }
   readonly #profit = computed(() => {
-    const margin = this.#margin();
+    const spread = this.#spread();
     const sign = this.assembly.crafted() ? 1 : -1;
-    return product(product(margin, sign), this.assembly.requested());
+    return product(product(spread, sign), this.assembly.requested());
   });
+
+  // get
 
   /**
    * The effective volume of materials required for the projection based on the craft parameters.

--- a/src/app/features/explorer/src/assembly.ts
+++ b/src/app/features/explorer/src/assembly.ts
@@ -1,6 +1,6 @@
 import { MatDialogConfig } from "@angular/material/dialog";
 
-import { defineColumn, defineTable } from "@app/core";
+import { defineColumn, defineTable, GetterFn } from "@app/core";
 import { getPriceInputs, getRatioInputs, NwIcon, NwPrice, NwRatio } from "@app/nw-buddy";
 import { Assembly, getIconInputs, getOpenerInputs, Opener } from "@features/artisan";
 import { Schematic } from "@features/schematic";
@@ -8,9 +8,11 @@ import { Schematic } from "@features/schematic";
 /**
  * Table definition for assemblies, which includes columns for various attributes of the assembly.
  */
-function getMarginState(assembly: Assembly): boolean | null {
-  const margin = assembly.margin;
-  return margin != null ? margin > 0 : null;
+function getValueState(getter: GetterFn<Assembly, number | null>): (assembly: Assembly) => boolean | null {
+  return assembly => {
+    const value = getter(assembly);
+    return value != null ? value > 0 : null;
+  }
 }
 
 /**
@@ -30,7 +32,7 @@ export const assemblyIcon = defineColumn<Assembly>('entity.icon',
 export const assemblyName = defineColumn<Assembly, string>('entity.name',
   'Name',
   { component: Opener, map: getOpenerInputs((x, i18n) => i18n.get(x.entity.name), Schematic, dialog) },
-  { width: '48%' }
+  { width: '43%' }
 );
 
 export const assemblyCategory = defineColumn<Assembly, string>('entity.category',
@@ -75,9 +77,21 @@ export const assemblyCost = defineColumn<Assembly, number>('cost',
   { width: '5%', align: 'right' }
 );
 
+export const assemblySpread = defineColumn<Assembly, number>('spread',
+  'Spread',
+  { component: NwPrice, map: getPriceInputs(x => x.spread, { getter: getValueState(x => x.spread), format: '1.2-2' }) },
+  { width: '5%', align: 'right' }
+);
+
 export const assemblyMargin = defineColumn<Assembly, number>('margin',
   'Margin',
-  { component: NwPrice, map: getPriceInputs(x => x.margin, { getter: getMarginState, format: '1.2-2' }) },
+  { component: NwRatio, map: getRatioInputs(x => x.margin, { getter: getValueState(x => x.margin), format: '1.2-2' }) },
+  { width: '5%', align: 'right' }
+);
+
+export const assemblyProfit = defineColumn<Assembly, number>('profit',
+  'Profit',
+  { component: NwPrice, map: getPriceInputs(x => x.profit, { getter: getValueState(x => x.profit), format: '1.2-2' }) },
   { width: '5%', align: 'right' }
 );
 
@@ -92,5 +106,5 @@ export const assemblyTable = defineTable<Assembly>('assemblies',
   assemblyCategory, assemblyFamily,
   assemblyType, assemblyTier, assemblyBlueprints,
   assemblyPrice, assemblyCost,
-  assemblyMargin, assemblyChance
+  assemblySpread, assemblyMargin, assemblyChance
 );

--- a/src/app/features/explorer/src/assembly.ts
+++ b/src/app/features/explorer/src/assembly.ts
@@ -57,7 +57,7 @@ export const assemblyTier = defineColumn<Assembly, number>('entity.tier',
   { width: '5%' }
 );
 
-export const assemblyBlueprints = defineColumn<Assembly, number>('entity.blueprints',
+export const assemblyBlueprints = defineColumn<Assembly, number>('entity.blueprints.length',
   'Recipes',
   { fit: x => x.entity.blueprints.length },
   { width: '2%' }
@@ -69,19 +69,19 @@ export const assemblyPrice = defineColumn<Assembly, number>('entity.price',
   { width: '5%', align: 'right' }
 );
 
-export const assemblyCost = defineColumn<Assembly, number>('projection.cost',
+export const assemblyCost = defineColumn<Assembly, number>('cost',
   'Cost',
   { component: NwPrice, map: getPriceInputs(x => x.cost ?? null, { format: '1.2-2' }) },
   { width: '5%', align: 'right' }
 );
 
-export const assemblyMargin = defineColumn<Assembly, number>('projection.margin',
+export const assemblyMargin = defineColumn<Assembly, number>('margin',
   'Margin',
   { component: NwPrice, map: getPriceInputs(x => x.margin, { getter: getMarginState, format: '1.2-2' }) },
   { width: '5%', align: 'right' }
 );
 
-export const assemblyChance = defineColumn<Assembly, number | null>('projection.yieldBonusChance',
+export const assemblyChance = defineColumn<Assembly, number | null>('yieldBonusChance',
   'Chance',
   { component: NwRatio, map: getRatioInputs(x => x.yieldBonusChance, { format: '1.0-2' }) },
   { width: '5%', align: 'right' }

--- a/src/app/features/explorer/src/explorer.html
+++ b/src/app/features/explorer/src/explorer.html
@@ -25,4 +25,4 @@
   <tr mat-header-row *matHeaderRowDef="_craftables | columns"></tr>
   <tr mat-row *matRowDef="let row; columns: _craftables | columns;"></tr>
 </table>
-<mat-paginator [length]="50" [pageSizeOptions]="_pages()" aria-label="Select page"></mat-paginator>
+<mat-paginator [pageSizeOptions]="_pages()" aria-label="Select page"></mat-paginator>

--- a/src/app/features/explorer/src/explorer.html
+++ b/src/app/features/explorer/src/explorer.html
@@ -1,3 +1,9 @@
+<form>
+  <mat-form-field>
+    <input matInput placeholder="Search..." [formControl]="_search" />
+  </mat-form-field>
+</form>
+
 <table mat-table [dataSource]="_data" matSort class="mat-elevation-z8">
 
   @for (column of _craftables.columns; track column.id) {

--- a/src/app/features/explorer/src/explorer.html
+++ b/src/app/features/explorer/src/explorer.html
@@ -1,6 +1,6 @@
-<table mat-table [dataSource]="data" matSort class="mat-elevation-z8">
+<table mat-table [dataSource]="_data" matSort class="mat-elevation-z8">
 
-  @for (column of craftables.columns; track column.id) {
+  @for (column of _craftables.columns; track column.id) {
   <ng-container [matColumnDef]="column.id">
     <th mat-header-cell [mat-sort-header]="column.id" *matHeaderCellDef [width]="column.width">
       {{column.displayName}}
@@ -16,6 +16,7 @@
   </ng-container>
   }
 
-  <tr mat-header-row *matHeaderRowDef="craftables | columns"></tr>
-  <tr mat-row *matRowDef="let row; columns: craftables | columns;"></tr>
+  <tr mat-header-row *matHeaderRowDef="_craftables | columns"></tr>
+  <tr mat-row *matRowDef="let row; columns: _craftables | columns;"></tr>
 </table>
+<mat-paginator [length]="50" [pageSizeOptions]="_pages()" aria-label="Select page"></mat-paginator>

--- a/src/app/features/schematic/src/resource.ts
+++ b/src/app/features/schematic/src/resource.ts
@@ -3,6 +3,7 @@ import { DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
+import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltip } from '@angular/material/tooltip';
@@ -16,7 +17,7 @@ import { NwIcon, LocalizePipe, NwPrice, StatePipe } from '@app/nw-buddy';
   imports: [
     DecimalPipe, FormsModule,
     MatCardModule, MatTableModule,
-    MatButton, MatSlideToggle, MatTooltip,
+    MatInput, MatButton, MatSlideToggle, MatTooltip,
     NwIcon, NwPrice, InstancePipe, LocalizePipe,
     StatePipe
 ],

--- a/src/app/nw-buddy/src/nw-i18n.ts
+++ b/src/app/nw-buddy/src/nw-i18n.ts
@@ -1,9 +1,37 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 
+import { AccessorFn } from '@app/core';
 import { NwBuddyApi } from './nw-buddy-api';
 
+/**
+ * A mapping of localization keys to their corresponding translated strings.
+ */
 export type Localization = Record<string, string>;
+
+/**
+ * A mapping of property paths to translation functions.
+ */
+export type I18nMap = Record<string, (id: string) => string>;
+
+/**
+ * Creates an accessor function that translates string values based on the provided fields map.
+ * @param accessor The original accessor function.
+ * @param fields The mapping of property paths to translation functions.
+ * @returns A new accessor function that applies translations.
+ */
+export function getAccessor<T>(accessor: AccessorFn<T>, fields: I18nMap): AccessorFn<T> {
+  return (item, segments) => {
+    const value = accessor(item, segments);
+    if (typeof value === 'string') {
+      const translate = fields[segments.join('.')];
+      if (translate) {
+        return translate(value);
+      }
+    }
+    return value;
+  };
+};
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/nw-buddy/src/nw-ratio.scss
+++ b/src/app/nw-buddy/src/nw-ratio.scss
@@ -1,0 +1,12 @@
+:host {
+  --nw-negative-color: #f44336;
+  --nw-positive-color: #69f0ae;
+
+  &.nw-positive {
+    color: var(--nw-positive-color);
+  }
+
+  &.nw-negative {
+    color: var(--nw-negative-color);
+  }
+}

--- a/src/app/nw-buddy/src/nw-ratio.spec.ts
+++ b/src/app/nw-buddy/src/nw-ratio.spec.ts
@@ -81,12 +81,24 @@ describe('getRatioInputs', () => {
   it('should return ratio inputs', () => {
     const object = { value: 42 };
     const inputs = getRatioInputs<Inputs, number>(x => x.value)(object);
-    expect(inputs).toEqual({ value: 42, format: undefined });
+    expect(inputs).toEqual({ value: 42, state: null, format: undefined });
+  });
+
+  it('should return price inputs with positive state', () => {
+    const object = { value: 42, state: true };
+    const inputs = getRatioInputs<Inputs, number>(x => x.value, { getter: x => x.state ?? null })(object);
+    expect(inputs).toEqual({ value: 42, state: true, format: undefined });
+  });
+
+  it('should return price inputs with negative state', () => {
+    const object = { value: 42, state: false };
+    const inputs = getRatioInputs<Inputs, number>(x => x.value, { getter: x => x.state ?? null })(object);
+    expect(inputs).toEqual({ value: 42, state: false, format: undefined });
   });
 
   it('should set ratio format', () => {
     const object = { value: 42.05 };
     const inputs = getRatioInputs<Inputs, number>(x => x.value, { format: '1.0-0' })(object);
-    expect(inputs).toEqual({ value: 42.05, format: '1.0-0' });
+    expect(inputs).toEqual({ value: 42.05, state: null, format: '1.0-0' });
   });
 });

--- a/src/app/nw-buddy/src/object-cache.ts
+++ b/src/app/nw-buddy/src/object-cache.ts
@@ -9,7 +9,7 @@ type HydrateFn<T> = (name: string, value: T) => void;
 type IteratorFn<T> = (data: Record<string, T[]>) => void;
 
 export abstract class CacheBase<T> {
-  readonly #subscription: Subscription[] = [];
+  readonly #subscriptions: Subscription[] = [];
   readonly #version = signal(0);
 
   readonly version = this.#version.asReadonly();
@@ -30,12 +30,12 @@ export abstract class CacheBase<T> {
   }
 
   protected _subscribe<T>(source: Observable<T>): void {
-    this.#subscription.push(source.subscribe());
+    this.#subscriptions.push(source.subscribe());
   }
 
   destroy(): void {
-    while (this.#subscription.length) {
-      this.#subscription.shift()?.unsubscribe();
+    while (this.#subscriptions.length) {
+      this.#subscriptions.shift()?.unsubscribe();
     }
   }
 }
@@ -109,19 +109,19 @@ export class CollectionCache<T> extends CacheBase<T> {
 }
 
 export class ArrayCache<T> {
-  readonly #subscription: Subscription[] = [];
+  readonly #subscriptions: Subscription[] = [];
   readonly #version = signal(0);
   readonly #objects = new Map<number, T>();
 
   readonly version = this.#version.asReadonly();
 
   protected _subscribe<T>(source: Observable<T>): void {
-    this.#subscription.push(source.subscribe());
+    this.#subscriptions.push(source.subscribe());
   }
 
   destroy(): void {
-    while (this.#subscription.length) {
-      this.#subscription.shift()?.unsubscribe();
+    while (this.#subscriptions.length) {
+      this.#subscriptions.shift()?.unsubscribe();
     }
   }
 


### PR DESCRIPTION
What's changed:

This pull request introduces a new data source architecture for the application, focused on extensibility and testability for table-like components. The main changes include adding a generic base data source (`DataSourceBase`), a specialized OData data source (`ODataSource`), and comprehensive test suites for both. Additionally, supporting exports and a new dependency have been added, along with minor UI improvements.

**Core Data Source Infrastructure:**

* Added a generic, extensible `DataSourceBase` class in `src/app/core/src/data-source-base.ts` to provide filtering, sorting, and pagination logic for table-like components, including a robust deep comparison utility (`deepComparator`).
* Introduced `ODataSource` in `src/app/core/src/odata-source.ts`, which builds on `DataSourceBase` to support OData-style queries and result sets, with observable loading state and query construction helpers.

**Testing and Utilities:**

* Added comprehensive unit tests for both `DataSourceBase` (`src/app/core/src/data-source-base.spec.ts`) and `ODataSource` (`src/app/core/src/odata-source.spec.ts`), including test helpers for pagination, sorting, filtering, and OData result simulation.

**Exports and Package Management:**

* Exported new data source modules in `src/app/core/index.ts` for broader usage in the application.
* Added the `uuid` package to `package.json` as a new dependency for generating unique identifiers in tests.

**UI and Configuration Improvements:**

* Added bottom margin to the toolbar in `src/app/app.scss` for improved spacing.
* Commented out unused item classes provider in `src/app/app.config.ts` for configuration clarity.