### PR TITLE
feature: Display server age in dropdown selector

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -13,8 +13,10 @@
     <mat-menu #server="matMenu">
       @for (server of _gaming.servers(); track server.name) {
       <button mat-menu-item id="server-{{server.name}}" (click)="_gaming.select(server)">
-        <span>{{server.name}}</span>
-        <span>({{server.age}})</span>
+        <span class="app-dropdown-item">
+          <span>{{server.name}}</span>
+          <span class="app-timespan">({{server.age / 60 | number: '1.0-0'}}h ago)</span>
+        </span>
       </button>
       }
     </mat-menu>

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -14,4 +14,9 @@
   gap: 1rem;
   justify-content: space-between;
   white-space: nowrap;
+
+  .app-timespan {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.875rem;
+  }
 }

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -8,3 +8,10 @@
     flex: 1 1 auto;
   }
 }
+
+.app-dropdown-item {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  white-space: nowrap;
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatMenuModule } from '@angular/material/menu';
@@ -11,7 +12,7 @@ import { GamingTools } from '@app/gaming-tools';
 @Component({
   selector: 'app-root',
   imports: [
-    RouterOutlet, RouterLink,
+    RouterOutlet, RouterLink, DecimalPipe,
     MatToolbarModule, MatMenuModule,
     MatButtonModule, MatIconModule
   ],


### PR DESCRIPTION
What's changed:

This pull request improves the display of server information in the dropdown menu by formatting the server age as hours ago and enhancing the visual layout for better readability. The most important changes are grouped below:

**UI/UX Improvements:**

* The server age is now displayed in hours (rounded to the nearest whole number) with a label like "xh ago" instead of raw minutes, making the information more user-friendly.
* The server dropdown menu items have been visually enhanced: a new `.app-dropdown-item` class arranges the server name and age in a flexible row, and the age is styled with a lighter color and smaller font for clarity.

**Codebase Updates:**

* Added `DecimalPipe` import to format the server age as a number in the template.
* Registered `DecimalPipe` in the component's imports to enable its use in the template.