### PR TITLE
feature: Persistent search context

### DIFF
--- a/src/app/features/explorer/src/explorer.ts
+++ b/src/app/features/explorer/src/explorer.ts
@@ -21,6 +21,7 @@ import { assemblyTable } from './assembly';
 export const EXPLORE_ITEM_CATEGORIES = new InjectionToken<CraftingCategory[]>('EXPLORE_ITEM_CATEGORIES');
 export const EXPLORE_ITEM_CLASSES = new InjectionToken<ItemClass[]>('EXPLORE_ITEM_CLASSES');
 
+const APP_EXPLORER_QUERY = 'explorer.query';
 const APP_EXPLORER_FILTERS = 'explorer.filters';
 const defaults = getStorageItem(APP_EXPLORER_FILTERS, {
   category: null,
@@ -114,7 +115,7 @@ export class Explorer implements OnDestroy {
     'entity.type': key => this._i18n.get(key, 'UI', 'UI_ItemTypeDescription'),
   };
 
-  protected readonly _search = new FormControl<string | null>(null);
+  protected readonly _search = new FormControl<string | null>(getStorageItem<string | null>(APP_EXPLORER_QUERY, null));
   protected readonly _category = new FormControl<CraftingCategory | null>(defaults.category);
   protected readonly _family = new FormControl<TradingFamily | null>(defaults.family);
   protected readonly _type = new FormControl<ItemType | null>(defaults.type);
@@ -128,8 +129,10 @@ export class Explorer implements OnDestroy {
     this._data.accessor = getAccessor(this._data.accessor, this.#fields);
     this._data.predicate = getPredicate;
     this.#subscriptions.push(this._search.valueChanges.pipe(
+      startWith(this._search.value),
       distinctUntilChanged(),
       debounceTime(200),
+      tap(value => setStorageItem(APP_EXPLORER_QUERY, value)),
       tap(value => this._data.query = value)
     ).subscribe());
     this.#subscriptions.push(combineLatest([

--- a/src/app/features/explorer/src/explorer.ts
+++ b/src/app/features/explorer/src/explorer.ts
@@ -129,9 +129,9 @@ export class Explorer implements OnDestroy {
     this._data.accessor = getAccessor(this._data.accessor, this.#fields);
     this._data.predicate = getPredicate;
     this.#subscriptions.push(this._search.valueChanges.pipe(
-      startWith(this._search.value),
       distinctUntilChanged(),
       debounceTime(200),
+      startWith(this._search.value),
       tap(value => setStorageItem(APP_EXPLORER_QUERY, value)),
       tap(value => this._data.query = value)
     ).subscribe());

--- a/src/app/features/schematic/src/resource.html
+++ b/src/app/features/schematic/src/resource.html
@@ -18,7 +18,7 @@
       @if (purchase) {
       <mat-card-subtitle class="app-l-flex app-l-flex-row">
         <div class="app-l-flex-spacer-1r">
-          {{purchase.requested()}}
+          {{purchase.requested() | number: '1.0-2'}}
           <span class="app-action"> x </span>
           @if (assembly && purchase.crafted()) {
           <span nw-price [value]="purchase.value"></span>
@@ -60,10 +60,10 @@
             <input matInput type="number" [(ngModel)]="purchase.requested">
             }
             @else{
-            <b [matTooltip]="tooltips.requested">{{purchase.requested()}}</b>
+            <b [matTooltip]="tooltips.requested">{{purchase.requested() | number: '1.0-2'}}</b>
             }
             @if (assembly && purchase.crafted() && purchase.boosted()) {
-            / <b [matTooltip]="tooltips.effective">{{purchase.effective}}</b>
+            / <b [matTooltip]="tooltips.effective">{{purchase.effective | number: '1.0-2'}}</b>
             }
           </div>
         </div>
@@ -95,7 +95,7 @@
           <td mat-cell *matCellDef="let provision" [attr.colspan]="columns.length"> {{provision.ingredient.name | localize}} </td>
         </ng-container>
         <ng-container matColumnDef="quantity">
-          <td mat-cell *matCellDef="let provision"> {{provision.ingredient.quantity}} </td>
+          <td mat-cell *matCellDef="let provision"> {{provision.ingredient.quantity | number: '1.0-2'}} </td>
         </ng-container>
         <ng-container matColumnDef="action">
           <td mat-cell *matCellDef="let provision"> x </td>


### PR DESCRIPTION
What's changed:

This pull request introduces improvements to the explorer's search state persistence and enhances the display formatting of numeric values in the schematic resource view. The main changes ensure that the user's search query is saved and restored across sessions, and that numeric quantities are consistently shown with up to two decimal places for better readability.

**Explorer search state persistence:**
- Added a new constant `APP_EXPLORER_QUERY` and updated the explorer's search form control to initialize from local storage, ensuring the search query persists between sessions. The search value is now saved to local storage whenever it changes.

**Numeric formatting improvements in schematic resource view:**
- Updated all relevant numeric displays (such as `purchase.requested`, `purchase.effective`, and `provision.ingredient.quantity`) in `resource.html` to use the Angular `number` pipe with the format `'1.0-2'`, ensuring values are displayed with up to two decimal places.