### PR TITLE
feature: Asymptotic material evaluation

### DIFF
--- a/src/app/features/artisan/src/assembly.spec.ts
+++ b/src/app/features/artisan/src/assembly.spec.ts
@@ -129,6 +129,26 @@ describe('Assembly', () => {
     expect(assembly.crafted()).toBe(true);
   });
 
+  it('should toggle boosted crafting', () => {
+    const craftable = service.getCraftable('IngotT2');
+    const assembly = new Assembly(craftable);
+    expect(assembly.boosted()).toBe(true);
+
+    assembly.toggle();
+    expect(assembly.boosted()).toBe(false);
+  });
+
+  it('should clone assembly', () => {
+    const craftable = service.getCraftable('IngotT2');
+    const assembly = new Assembly(craftable);
+
+    const clone = assembly.clone();
+    expect(clone).toBeInstanceOf(Assembly);
+    expect(clone.entity).toBe(assembly.entity);
+    expect(clone).not.toBe(assembly);
+    expect(clone.materials).not.toBe(assembly.materials);
+  });
+
   it('should get state', () => {
     const craftable = service.getCraftable('IngotT2');
     const assembly = new Assembly(craftable);

--- a/src/app/features/artisan/src/assembly.ts
+++ b/src/app/features/artisan/src/assembly.ts
@@ -2,7 +2,7 @@ import { computed, signal } from '@angular/core';
 
 import { Persistent } from './contracts';
 import { Craftable } from './craftable';
-import { Materials } from './materials';
+import { Materials, MaterialsOptions } from './materials';
 import { Purchase, PurchaseState } from './purchase';
 import { Projection } from './projection';
 
@@ -131,6 +131,15 @@ export class Assembly extends Purchase implements Persistent<AssemblyState> {
    */
   toggle(): void {
     this.boosted.set(!this.boosted());
+  }
+
+  /**
+   * Clones the current assembly instance.
+   * @param options The materials options to use for the new instance.
+   * @returns A new Assembly instance with the same entity.
+   */
+  clone(options?: MaterialsOptions): Assembly {
+    return new Assembly(this.entity, new Materials(options));
   }
 
   /** @inheritdoc */

--- a/src/app/features/artisan/src/materials.ts
+++ b/src/app/features/artisan/src/materials.ts
@@ -1,3 +1,5 @@
+import { signal, WritableSignal } from "@angular/core";
+
 import { Persistent, Providable } from "./contracts";
 import { Assembly } from "./assembly";
 import { Purchase, PurchaseState } from "./purchase";
@@ -43,6 +45,16 @@ export interface MaterialsState {
 export const MATERIALS_STORAGE_KEY = 'materials';
 
 /**
+ * Options for configuring the Materials instance.
+ */
+export interface MaterialsOptions {
+  /**
+   * Indicates whether the price calculations are based on asymptotically infinite requested volumes.
+   */
+  asymptotic?: boolean;
+}
+
+/**
  * Represents an index of materials used in assembly planning.
  */
 export class Materials implements Persistent<MaterialsState> {
@@ -61,6 +73,20 @@ export class Materials implements Persistent<MaterialsState> {
    */
   get assembly(): Assembly | null {
     return this.#assembly;
+  }
+
+  /**
+   * Indicates whether the price calculation are based on asymptotically infinite
+   * requested volumes.
+   */
+  readonly asymptotic: WritableSignal<boolean>;
+
+  /**
+   * Creates a new Materials instance.
+   * @param options The options to configure the materials instance.
+   */
+  constructor(options?: MaterialsOptions) {
+    this.asymptotic = signal(options?.asymptotic ?? false);
   }
 
   /**

--- a/src/app/features/artisan/src/materials.ts
+++ b/src/app/features/artisan/src/materials.ts
@@ -76,7 +76,7 @@ export class Materials implements Persistent<MaterialsState> {
   }
 
   /**
-   * Indicates whether the price calculation are based on asymptotically infinite
+   * Indicates whether the price calculations are based on asymptotically infinite
    * requested volumes.
    */
   readonly asymptotic: WritableSignal<boolean>;

--- a/src/app/features/artisan/src/opener.spec.ts
+++ b/src/app/features/artisan/src/opener.spec.ts
@@ -90,6 +90,17 @@ describe('Opener', () => {
     const dialog = await loader.getHarness(MatDialogHarness);
     expect(await dialog.getText()).toBe(data.message);
   });
+
+  it('should open dialog with handler', async () => {
+    const data = { message: 'Test Dialog' };
+    const handler = (obj: typeof data) => ({ message: obj.message + ' Handled' });
+    fixture.componentRef.setInput('config', { data });
+    fixture.componentRef.setInput('handler', handler);
+    await harness.click();
+
+    const dialog = await loader.getHarness(MatDialogHarness);
+    expect(await dialog.getText()).toBe('Test Dialog Handled');
+  });
 });
 
 @Component({

--- a/src/app/features/artisan/src/opener.spec.ts
+++ b/src/app/features/artisan/src/opener.spec.ts
@@ -26,8 +26,17 @@ describe('getOpenerInputs', () => {
     const object = { name: 'Test', value: 42 };
     const i18n = { translate: (key: string) => key } as unknown as I18n;
 
-    const inputs = getOpenerInputs<typeof object, string, TestDialog>(x => x.name, TestDialog, {})(object, i18n);
-    expect(inputs).toEqual({ value: 'Test', component: TestDialog, config: { data: object } });
+    const inputs = getOpenerInputs<typeof object, string, TestDialog>(x => x.name, { component: TestDialog, config: {} })(object, i18n);
+    expect(inputs).toEqual({ value: 'Test', component: TestDialog, config: { data: object }, handler: undefined });
+  });
+
+  it('should return opener inputs without handler', () => {
+    const object = { name: 'Test', value: 42 };
+    const i18n = { translate: (key: string) => key } as unknown as I18n;
+    const handler = (value: typeof object) => value;
+
+    const inputs = getOpenerInputs<typeof object, string, TestDialog>(x => x.name, { component: TestDialog, config: {}, handler })(object, i18n);
+    expect(inputs).toEqual({ value: 'Test', component: TestDialog, config: { data: object }, handler });
   });
 });
 

--- a/src/app/features/artisan/src/opener.ts
+++ b/src/app/features/artisan/src/opener.ts
@@ -4,18 +4,46 @@ import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dial
 import { FitterFn, I18n } from '@app/core';
 
 /**
+ * A function that handles additional logic when opening the dialog.
+ * @param object The object being handled.
+ * @template T The type of the object to handle.
+ */
+export type HandlerFn<T> = (object: T) => T;
+
+/**
+ * Options for configuring the input display.
+ * @template T The type of the object to get the value from.
+ * @template C The type of the component to use for the dialog.
+ */
+interface InputOptions<T, C> {
+  /**
+   * The component to use for the dialog.
+   */
+  component: Type<C>;
+
+  /**
+   * The configuration for the dialog.
+   */
+  config: MatDialogConfig<T>;
+
+  /**
+   * An optional handler function to execute when opening the dialog.
+   */
+  handler?: HandlerFn<T> | null;
+}
+
+/**
  * Gets the inputs for an opener component.
  * @template T The type of the object to get the value from.
  * @template R The type of the value to display.
  * @template C The type of the component to use for the dialog.
  * @param fitter A function that gets a value from an object to display.
- * @param component The component to use for the dialog.
- * @param config The configuration for the dialog.
+ * @param options Options for configuring the input display.
  * @returns A function that takes an object and returns the inputs for the dialog.
  */
-export function getOpenerInputs<T, R, C>(fitter: FitterFn<T, R>, component: Type<C>, config: MatDialogConfig<T>) {
+export function getOpenerInputs<T, R, C>(fitter: FitterFn<T, R>, { component, config, handler }: InputOptions<T, C>) {
   return (object: T, i18n: I18n) => {
-    return { value: fitter(object, i18n), component, config: { ...config, data: object } };
+    return { value: fitter(object, i18n), component, config: { ...config, data: object }, handler };
   };
 }
 
@@ -40,6 +68,7 @@ export class Opener<C, T> implements OnDestroy {
   readonly component = input.required<Type<C>>();
   readonly config = input<MatDialogConfig<T>>({});
   readonly value = input<string | null>();
+  readonly handler = input<HandlerFn<T> | null>();
 
   /** @inheritdoc */
   ngOnDestroy(): void {
@@ -52,6 +81,11 @@ export class Opener<C, T> implements OnDestroy {
    * Opens the dialog with the specified component and configuration.
    */
   open(): void {
-    this.#refs.push(this.#dialog.open(this.component(), this.config()));
+    const config = this.config();
+    const handler = this.handler();
+    if (handler && config.data) {
+      config.data = handler(config.data);
+    }
+    this.#refs.push(this.#dialog.open(this.component(), config));
   }
 }

--- a/src/app/features/artisan/src/production.spec.ts
+++ b/src/app/features/artisan/src/production.spec.ts
@@ -117,6 +117,17 @@ describe('Production', () => {
     expect(production.effective).toBe(2);
   });
 
+  it('should clone production', () => {
+    const craftable = service.getCraftable('IngotT2');
+    const production = new Production(craftable);
+
+    const clone = production.clone();
+    expect(clone).toBeInstanceOf(Production);
+    expect(clone.entity).toBe(production.entity);
+    expect(clone).not.toBe(production);
+    expect(clone.materials).not.toBe(production.materials);
+  });
+
   it('should get state', () => {
     const craftable = service.getCraftable('IngotT2');
     const production = new Production(craftable);

--- a/src/app/features/artisan/src/production.spec.ts
+++ b/src/app/features/artisan/src/production.spec.ts
@@ -80,8 +80,8 @@ describe('Production', () => {
   volumes.forEach(({ id, crafted, requested, expected }) => {
     it('should compute requested volume', () => {
       const craftable = service.getCraftable(id);
-      const materials = new Materials();
-      const production = new Production(craftable, materials);
+      const production = new Production(craftable);
+      const materials = production.materials;
       production.crafted.set(crafted);
       production.requested.set(requested);
       expect(materials.ids.map(extract(materials, x => x.requested()))).toEqual(expected);
@@ -96,8 +96,8 @@ describe('Production', () => {
   values.forEach(({ id, crafted, requested, expected }) => {
     it('should compute total value', () => {
       const craftable = service.getCraftable(id);
-      const materials = new Materials();
-      const production = new Production(craftable, materials);
+      const production = new Production(craftable);
+      const materials = production.materials;
       production.crafted.set(crafted);
       production.requested.set(requested);
       expect(materials.ids.map(extract(materials, x => x.total))).toEqual(expected);
@@ -106,15 +106,13 @@ describe('Production', () => {
 
   it('should compute effective volume by default', () => {
     const craftable = service.getCraftable('IngotT2');
-    const materials = new Materials();
-    const production = new Production(craftable, materials);
+    const production = new Production(craftable);
     expect(production.effective).toBe(1);
   });
 
   it('should compute effective volume', () => {
     const craftable = service.getCraftable('IngotT2');
-    const materials = new Materials();
-    const production = new Production(craftable, materials);
+    const production = new Production(craftable);
     production.requested.set(3);
     expect(production.effective).toBe(2);
   });

--- a/src/app/features/artisan/src/production.ts
+++ b/src/app/features/artisan/src/production.ts
@@ -2,6 +2,8 @@ import { signal } from "@angular/core";
 
 import { Assembly, AssemblyState } from "./assembly";
 import { Persistent } from "./contracts";
+import { Craftable } from "./craftable";
+import { Materials, MaterialsOptions } from "./materials";
 
 /**
  * Represents the state of an assembly.
@@ -10,9 +12,21 @@ export interface ProductionState extends AssemblyState {
   requested: number;
 }
 
+/**
+ * Represents a production order for a craftable item, extending assembly with requested volume.
+ */
 export class Production extends Assembly implements Persistent<ProductionState> {
   /** @inheritdoc */
   override readonly requested = signal(1);
+
+  /**
+   * Creates a new Production instance.
+   * @param entity The craftable item to produce.
+   * @param options The options to configure the materials instance.
+   */
+  constructor(entity: Craftable, options?: MaterialsOptions) {
+    super(entity, new Materials(options));
+  }
 
   /** @inheritdoc */
   override getState(): ProductionState {

--- a/src/app/features/artisan/src/production.ts
+++ b/src/app/features/artisan/src/production.ts
@@ -29,6 +29,11 @@ export class Production extends Assembly implements Persistent<ProductionState> 
   }
 
   /** @inheritdoc */
+  override clone(options?: MaterialsOptions): Production {
+    return new Production(this.entity, options);
+  }
+
+  /** @inheritdoc */
   override getState(): ProductionState {
     return {
       requested: this.requested(),

--- a/src/app/features/artisan/src/projection.ts
+++ b/src/app/features/artisan/src/projection.ts
@@ -107,11 +107,14 @@ export class Projection {
   }
   readonly #effective = computed(() => {
     const chance = this.yieldBonusChance;
-    const requested = this.assembly.requested();
-    if (this.assembly.boosted() && chance && requested) {
-      return Math.max(Math.floor(requested / (1 + chance)), 1);
+    let value = this.assembly.requested();
+    if (this.assembly.boosted() && chance && value) {
+      value = value / (1 + chance);
+      if (!this.materials.asymptotic()) {
+        value = Math.max(Math.floor(value), 1);
+      }
     }
-    return requested;
+    return value;
   });
 
   /**

--- a/src/app/features/explorer/src/assembly.ts
+++ b/src/app/features/explorer/src/assembly.ts
@@ -1,9 +1,22 @@
 import { MatDialogConfig } from "@angular/material/dialog";
 
-import { defineColumn, defineTable } from "@app/core";
+import { defineColumn, defineTable, getStorageItem } from "@app/core";
 import { getPriceInputs, getRatioInputs, NwIcon, NwPrice, NwRatio } from "@app/nw-buddy";
-import { Assembly, getIconInputs, getOpenerInputs, Opener } from "@features/artisan";
+import { Assembly, getIconInputs, getOpenerInputs, MATERIALS_STORAGE_KEY, MaterialsState, Opener } from "@features/artisan";
 import { Schematic } from "@features/schematic";
+
+/**
+ * Loads the state of the assembly from storage.
+ * @param assembly The assembly to load the state for.
+ */
+function assemblyHandler(assembly: Assembly): Assembly {
+  const materials = getStorageItem<Record<string, MaterialsState>>(MATERIALS_STORAGE_KEY, {});
+  if (materials) {
+    const state = materials[assembly.entity.id];
+    state && assembly.materials.setState(state);
+  }
+  return assembly;
+}
 
 /**
  * Dialog configuration for the Schematic component.
@@ -21,7 +34,13 @@ export const assemblyIcon = defineColumn<Assembly>('entity.icon',
 
 export const assemblyName = defineColumn<Assembly, string>('entity.name',
   'Name',
-  { component: Opener, map: getOpenerInputs((x, i18n) => i18n.get(x.entity.name), Schematic, dialog) },
+  {
+    component: Opener, map: getOpenerInputs((x, i18n) => i18n.get(x.entity.name), {
+      component: Schematic,
+      config: dialog,
+      handler: assemblyHandler
+    })
+  },
   { width: '43%' }
 );
 

--- a/src/app/features/explorer/src/assembly.ts
+++ b/src/app/features/explorer/src/assembly.ts
@@ -10,6 +10,7 @@ import { Schematic } from "@features/schematic";
  * @param assembly The assembly to load the state for.
  */
 function assemblyHandler(assembly: Assembly): Assembly {
+  assembly = assembly.clone({ asymptotic: false });
   const materials = getStorageItem<Record<string, MaterialsState>>(MATERIALS_STORAGE_KEY, {});
   if (materials) {
     const state = materials[assembly.entity.id];

--- a/src/app/features/explorer/src/explorer.ts
+++ b/src/app/features/explorer/src/explorer.ts
@@ -15,7 +15,7 @@ import { combineLatest, debounceTime, distinctUntilChanged, startWith, Subscript
 import { getStorageItem, GetterFn, GroupingSet, PredicateFn, QueryFilters, setStorageItem, SyncDataSource, TranslateFn } from '@app/core';
 import { CraftingCategory, CraftingRecipeData, ItemClass, ItemType, MasterItemDefinitions, TradingFamily } from '@app/nw-data';
 import { getAccessor, NwI18n, NwRatio } from '@app/nw-buddy';
-import { Artisan, ColumnPipe, ColumnsPipe, MATERIALS_STORAGE_KEY, MaterialsState, Production, supported } from '@features/artisan';
+import { Artisan, ColumnPipe, ColumnsPipe, Production, supported } from '@features/artisan';
 import { assemblyTable } from './assembly';
 
 export const EXPLORE_ITEM_CATEGORIES = new InjectionToken<CraftingCategory[]>('EXPLORE_ITEM_CATEGORIES');
@@ -176,14 +176,6 @@ export class Explorer implements OnDestroy {
     x => x.margin
   );
 
-  readonly #recover = effect(() => {
-    const materials = getStorageItem<Record<string, MaterialsState>>(MATERIALS_STORAGE_KEY, {});
-    const objects = this.#data();
-    for (const object of objects) {
-      const state = materials[object.entity.id];
-      state && object.materials.setState(state);
-    }
-  });
   readonly #refresh = effect(() => {
     this._data.data = this.#data();
   });
@@ -209,7 +201,6 @@ export class Explorer implements OnDestroy {
     while (this.#subscriptions.length) {
       this.#subscriptions.shift()?.unsubscribe();
     }
-    this.#recover.destroy();
     this.#refresh.destroy();
   }
 

--- a/src/app/features/explorer/src/explorer.ts
+++ b/src/app/features/explorer/src/explorer.ts
@@ -154,7 +154,7 @@ export class Explorer implements OnDestroy {
       const recipes = supported(this.#artisan.data.recipes.get(key));
       if (item && recipes?.length && !this._isExcluded(recipes) && this._isIncluded(item)) {
         const craftable = this.#artisan.getCraftable(key);
-        craftable && objects.push(new Production(craftable));
+        craftable && objects.push(new Production(craftable, { asymptotic: true }));
       }
     }
     return objects;

--- a/src/app/nw-buddy/src/nw-price.ts
+++ b/src/app/nw-buddy/src/nw-price.ts
@@ -16,15 +16,27 @@ interface Components {
   decimalOp: number | null;
 }
 
+/**
+ * Options for configuring the input display.
+ */
 interface InputOptions {
-  state?: boolean | null;
+  /**
+   * The display state of the price.
+   * @remarks If the number is provided, it will be used directly. If the boolean is provided
+   * and the value is true, the state will be rendered based on the value.
+   */
+  state?: number | boolean | null;
+
+  /**
+   * The number format to use for display.
+   */
   format?: string | null;
 }
 
 /**
  * Get the price inputs from a given item.
  * @param fitter A function that gets a value from an item to display.
- * @param getter A function that gets a state from an item to display.
+ * @param options Options for configuring the input display.
  * @returns A function that maps an item to its price inputs.
  */
 export function getPriceInputs<T, R>(fitter: GetterFn<T, R>, { state, format }: InputOptions = {}) {

--- a/src/app/nw-buddy/src/nw-ratio.ts
+++ b/src/app/nw-buddy/src/nw-ratio.ts
@@ -4,15 +4,27 @@ import { DecimalPipe } from '@angular/common';
 import { GetterFn } from '@app/core';
 import { stateAttribute } from './state-pipe';
 
+/**
+ * Options for configuring the input display.
+ */
 interface InputOptions {
-  state?: boolean | null;
+  /**
+   * The display state of the price.
+   * @remarks If the number is provided, it will be used directly. If the boolean is provided
+   * and the value is true, the state will be rendered based on the value.
+   */
+  state?: number | boolean | null;
+
+  /**
+   * The number format to use for display.
+   */
   format?: string | null;
 }
 
 /**
  * Get the ratio inputs from a given item.
  * @param fitter A function that gets a value from an item to display.
- * @param format The format to use for the value.
+ * @param options Options for configuring the input display.
  * @returns A function that maps an item to its ratio inputs.
  */
 export function getRatioInputs<T, R>(fitter: GetterFn<T, R>, { state, format }: InputOptions = {}) {


### PR DESCRIPTION
What's changed:

This pull request introduces several enhancements and refactors to the artisan and explorer modules, focusing on improved cloning, dialog handling, and more flexible configuration of materials and production logic. The most significant changes include support for cloning `Assembly` and `Production` instances with configurable options, the addition of handler logic for dialog openers, and adjustments to how materials are configured and restored across the application.

**Enhancements to cloning and configuration:**

- Added `clone` methods to both `Assembly` and `Production` classes, allowing instances to be duplicated with customizable `MaterialsOptions`, improving flexibility for state management and UI workflows.
- Refactored `Materials` to accept an `asymptotic` option, enabling price calculations based on infinite requested volumes, and updated related usages throughout the codebase.

**Dialog and opener improvements:**

- Enhanced the `getOpenerInputs` function and the `Opener` component to support an optional `handler` function, allowing for custom logic (such as state restoration or transformation) when opening dialogs.
- Updated tests and usages to verify and demonstrate the new handler functionality in dialog openers.

**Explorer state and production initialization:**

- Modified the explorer logic to initialize `Production` instances with the `asymptotic` option set to true, ensuring consistent behavior for bulk calculations.
- Removed the previous effect-based state recovery for materials in explorer, replacing it with handler-based restoration for assemblies via dialog openers.

**Testing and minor improvements:**

- Added and updated unit tests for cloning, boosted crafting toggling, and effective volume calculations to ensure correctness and coverage of new features.
- Improved documentation and typing for input options in price display utilities.

These changes collectively improve the modularity, testability, and user experience of the artisan and explorer features, particularly around state handling and dialog interactions.